### PR TITLE
Tinkering

### DIFF
--- a/COTL_API/Debug/DebugHelpers.cs
+++ b/COTL_API/Debug/DebugHelpers.cs
@@ -1,0 +1,26 @@
+﻿using HarmonyLib;
+using UnityEngine;
+
+namespace COTL_API.Debug;
+
+[HarmonyPatch]
+public static class DebugHelpers
+{
+    public static Interaction CurrentInteraction { get; private set; }
+    
+    [HarmonyPatch(typeof(Interaction), nameof(Interaction.OnInteract), typeof(StateMachine))]
+    public static class InteractionPatches
+    {
+        [HarmonyPostfix]
+        public static void Postfix(Interaction __instance)
+        {
+            if (!Plugin.Debug || __instance == null) return;
+            CurrentInteraction = __instance;
+            string message = "[Interaction]: ";
+            if(__instance.gameObject != null) message += $"GameObject Name: {__instance.gameObject}, ";
+            if (__instance.OutlineTarget != null) message += $"Outline target: {__instance.OutlineTarget.name}, ";
+            message += $"Name: {__instance.name}";
+            Plugin.Logger.LogWarning(message);
+        }
+    }
+}


### PR DESCRIPTION
- Logs interactions and their associated object names when debug mode is on
- Makes the interaction available to plugins at any point without having to do their own patches