### PR TITLE
fix: commands not closing menu

### DIFF
--- a/COTL_API/Debug/DebugFollowerCommand.cs
+++ b/COTL_API/Debug/DebugFollowerCommand.cs
@@ -1,4 +1,4 @@
-﻿namespace COTL_API.Debug;
+namespace COTL_API.Debug;
 
 public class DebugFollowerCommand : CustomFollowerCommand.CustomFollowerCommand
 {
@@ -27,6 +27,6 @@ public class DebugFollowerCommand : CustomFollowerCommand.CustomFollowerCommand
             interaction.eventListener.PlayFollowerVO(interaction.generalAcknowledgeVO);
             interaction.follower.Brain.HardSwapToTask(new FollowerTask_InstantPoop());
         }));
-        interaction.Close(true);
+        interaction.Close(true, reshowMenu: false);
     }
 }

--- a/COTL_API/Debug/DebugFollowerCommand2.cs
+++ b/COTL_API/Debug/DebugFollowerCommand2.cs
@@ -1,4 +1,4 @@
-﻿using COTL_API.CustomFollowerCommand;
+using COTL_API.CustomFollowerCommand;
 
 namespace COTL_API.Debug;
 
@@ -22,7 +22,7 @@ public class DebugFollowerCommandClass2 : CustomFollowerCommand.CustomFollowerCo
         FollowerCommands finalCommand = FollowerCommands.None)
     {
         interaction.follower.Brain.MakeDissenter();
-        interaction.Close(true);
+        interaction.Close(true, reshowMenu: false);
     }
 
     public DebugFollowerCommandClass2()

--- a/COTL_API/Debug/DebugFollowerCommand3.cs
+++ b/COTL_API/Debug/DebugFollowerCommand3.cs
@@ -22,6 +22,6 @@ public class DebugFollowerCommandClass3 : CustomFollowerCommand.CustomFollowerCo
     public override void Execute(interaction_FollowerInteraction interaction,
         FollowerCommands finalCommand = FollowerCommands.None)
     {
-        interaction.Close(true);
+        interaction.Close(true, reshowMenu: false);
     }
 }


### PR DESCRIPTION
for modders making commands in de future: 
- add reshowMenu: false to close() when the command is complete
- Example: ```interaction.Close(true, reshowMenu: false);```