### PR TITLE
Fix HatType and UnityEngine Dependency update

### DIFF
--- a/COTL_API.Common.props
+++ b/COTL_API.Common.props
@@ -33,7 +33,7 @@
         <PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all" />
         <PackageReference Include="BepInEx.Core" Version="5.4.21" />
         <PackageReference Include="BepInEx.PluginInfoProps" Version="2.*" />
-        <PackageReference Include="UnityEngine.Modules" Version="2019.4.40" IncludeAssets="compile" />
+        <PackageReference Include="UnityEngine.Modules" Version="2021.3.16" IncludeAssets="compile" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">

--- a/COTL_API/Debug/DebugTask.cs
+++ b/COTL_API/Debug/DebugTask.cs
@@ -1,4 +1,4 @@
-﻿using COTL_API.CustomTasks;
+using COTL_API.CustomTasks;
 using UnityEngine;
 
 namespace COTL_API.Debug;
@@ -53,12 +53,12 @@ public class DebugTask : CustomTask
     {
         base.Setup(follower);
         _follower = follower;
-        follower.SetHat(HatType.Miner);
+        follower.SetHat(FollowerHatType.Miner);
     }
 
     public override void Cleanup(Follower follower)
     {
-        follower.SetHat(HatType.None);
+        follower.SetHat(FollowerHatType.None);
         base.Cleanup(follower);
     }
 

--- a/COTL_API/Plugin.cs
+++ b/COTL_API/Plugin.cs
@@ -154,7 +154,7 @@ public class Plugin : BaseUnityPlugin
 
         LogInfo($"{MyPluginInfo.PLUGIN_NAME} loaded!");
 
-        GameHash.LogGameInfo();
+        //GameHash.LogGameInfo();
     }
 
     private void Start()

--- a/COTL_API/Prefabs/CustomPrefabManager.cs
+++ b/COTL_API/Prefabs/CustomPrefabManager.cs
@@ -1,4 +1,4 @@
-﻿using COTL_API.CustomStructures;
+using COTL_API.CustomStructures;
 using HarmonyLib;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
@@ -95,15 +95,13 @@ public static class CustomPrefabManager
 
     public static GameObject CreatePlacementObjectFor(CustomStructure structure)
     {
-        var obj =
-            Addressables.LoadAssetAsync<GameObject>(
-                "Assets/Prefabs/Placement Objects/Placement Object Security Turret Lvl2.prefab");
-        obj.WaitForCompletion();
-
-        var po = obj.Result.GetComponentInChildren<PlacementObject>();
+        var obj = TypeAndPlacementObjects.GetByType(StructureBrain.TYPES.BED).PlacementObject;
+        
+        var po = obj.GetComponent<PlacementObject>();
         po.ToBuildAsset = structure.PrefabPath;
         po.StructureType = structure.StructureType;
         po.Bounds = structure.Bounds;
-        return obj.Result;
+
+        return obj;
     }
 }


### PR DESCRIPTION
- update unity engine to 2021 so that it has the new modules for the TMP
- FollowerHatType
- LogGameInfo seems to unload the api due to empty string from assembly.location, so its temporarily commented out
