### PR TITLE
Fix ArgumentException by making enum parsing case-insensitive

### DIFF
--- a/COTL_API/CustomSkins/CustomSkinManager.cs
+++ b/COTL_API/CustomSkins/CustomSkinManager.cs
@@ -1,3 +1,4 @@
+using System;
 using HarmonyLib;
 using Spine;
 using Spine.Unity;
@@ -666,7 +667,7 @@ public static partial class CustomSkinManager
         try
         {
             var rName = simpleName.Split(':')[1];
-            var regionIndex = (int)(SkinSlots)Enum.Parse(typeof(SkinSlots), simpleName.Split(':')[0]);
+            var regionIndex = (int)(SkinSlots)Enum.Parse(typeof(SkinSlots), simpleName.Split(':')[0], true);
             region.name = regionIndex + ":" + rName + "#" + add;
             return [Tuple.Create(regionIndex, rName)];
         }

--- a/COTL_API/Helpers/KeyCodes.cs
+++ b/COTL_API/Helpers/KeyCodes.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 
 namespace COTL_API.Helpers;
 
@@ -11,7 +12,7 @@ public static class KeyCodes
 
     public static KeyCode StringToKeyCode(string keyCodeString)
     {
-        return (KeyCode)Enum.Parse(typeof(KeyCode), keyCodeString);
+        return (KeyCode)Enum.Parse(typeof(KeyCode), keyCodeString, true);
     }
 
     public static string[] GetKeyCodeOptions()

--- a/COTL_API/Patches/SettingsPatches.cs
+++ b/COTL_API/Patches/SettingsPatches.cs
@@ -1,4 +1,5 @@
-﻿using COTL_API.CustomSkins;
+﻿using System;
+using COTL_API.CustomSkins;
 using HarmonyLib;
 using Lamb.UI;
 using Lamb.UI.MainMenu;
@@ -39,10 +40,10 @@ public static class SettingsPatches
 
         if (Plugin.LambFleeceBleatSettings?.Value is not null && Plugin.LambFleeceBleatSettings.Value != "Default")
             CustomSkinManager.SetPlayerBleatOverride(PlayerType.LAMB,
-                (PlayerBleat)Enum.Parse(typeof(PlayerBleat), Plugin.LambFleeceBleatSettings.Value));
+                (PlayerBleat)Enum.Parse(typeof(PlayerBleat), Plugin.LambFleeceBleatSettings.Value, true));
 
         if (Plugin.GoatFleeceBleatSettings?.Value is not null && Plugin.GoatFleeceBleatSettings.Value != "Default")
             CustomSkinManager.SetPlayerBleatOverride(PlayerType.GOAT,
-                (PlayerBleat)Enum.Parse(typeof(PlayerBleat), Plugin.GoatFleeceBleatSettings.Value));
+                (PlayerBleat)Enum.Parse(typeof(PlayerBleat), Plugin.GoatFleeceBleatSettings.Value, true));
     }
 }


### PR DESCRIPTION
This pull request updates several files to improve the robustness of enum parsing by making it case-insensitive, and adds missing `using System;` directives where necessary. The main changes ensure that string values can be parsed into their respective enums regardless of letter casing, which helps prevent runtime errors due to case mismatches.

**Enum parsing improvements:**

* Updated all `Enum.Parse` calls to include the `ignoreCase: true` parameter, making enum parsing case-insensitive in `CustomSkinManager.cs`, `KeyCodes.cs`, and `SettingsPatches.cs`. [[1]](diffhunk://#diff-617567eb1681f5735b0ca54f02e792076db96606f79212eb021b8a70478f0e02L669-R670) [[2]](diffhunk://#diff-0c908df07a0a3763a972de2a78faf1d564b5ddef7fee4a713650f771dd811bdfL14-R15) [[3]](diffhunk://#diff-c70f0b65a7132a58bf378b61767a3e60ea02695b84b6a3d6a36b0663fb2e175eL42-R47)

**Code quality and consistency:**

* Added missing `using System;` directives to files that use enums and parsing, ensuring necessary namespaces are included in `CustomSkinManager.cs`, `KeyCodes.cs`, and `SettingsPatches.cs`. [[1]](diffhunk://#diff-617567eb1681f5735b0ca54f02e792076db96606f79212eb021b8a70478f0e02R1) [[2]](diffhunk://#diff-0c908df07a0a3763a972de2a78faf1d564b5ddef7fee4a713650f771dd811bdfL1-R2) [[3]](diffhunk://#diff-c70f0b65a7132a58bf378b61767a3e60ea02695b84b6a3d6a36b0663fb2e175eL1-R2)